### PR TITLE
specify version in installation instructions

### DIFF
--- a/docs/installation/graphical.rst
+++ b/docs/installation/graphical.rst
@@ -13,7 +13,7 @@ Graphical Installation
 SEAMM should be installed in the **seamm** conda environment. Open a terminal 
 and run the following commands::
 
-  conda create -n seamm -c conda-forge seamm seamm-installer
+  conda create -n seamm -c conda-forge seamm seamm-installer python=3.9
 
 Once the environment is in place, you can activate it as prompted::
 


### PR DESCRIPTION
The install command as written will install Python 3.10. There is a problem with the SEAMM installer graphical interface currently for Python 3.10, so let's direct people away from this until we fix it.